### PR TITLE
Dev

### DIFF
--- a/inc/Plotter.h
+++ b/inc/Plotter.h
@@ -101,6 +101,7 @@ private:
     TH1I *clusterSizeRow_all_;
     TH1I *clusterSizeCol_all_;
 
+    TH2I *clusterMap_all_;
     TH2I *clusterMap_cs1_all_;
     TH2I *clusterMap_cs2_all_;
     TH2D *clusterTotMap_cs1_all_;

--- a/src/Plotter.cpp
+++ b/src/Plotter.cpp
@@ -183,19 +183,20 @@ void Plotter::fillClusterPlots(Clusterizer::clusterMapDef &clusterMap, double no
     {
         std::cout << "Making new cluster histograms for quad." << std::endl;
 
-        clusterToT_all_             = addPlot(clusterToT_all_         ,"ToTdist"      ,150,-0.5,149.5);
-        clusterToT_cs1_all_         = addPlot(clusterToT_cs1_all_     ,"ToTdistCS1"   ,150,-0.5,149.5);
-        clusterToT_cs2_all_         = addPlot(clusterToT_cs2_all_     ,"ToTdistCS2"   ,150,-0.5,149.5);
-        clusterToT_cs3_all_         = addPlot(clusterToT_cs3_all_     ,"ToTdistCS3"   ,150,-0.5,149.5);
-        clusterToT_csn_all_         = addPlot(clusterToT_csn_all_     ,"ToTdistCSn"   ,150, -0.5, 149.5, 50, 0.5, 50.5);
+        clusterToT_all_             = addPlot(clusterToT_all_         ,"ToTdist"      ,80,-0.5,79.5);
+        clusterToT_cs1_all_         = addPlot(clusterToT_cs1_all_     ,"ToTdistCS1"   ,20,-0.5,19.5);
+        clusterToT_cs2_all_         = addPlot(clusterToT_cs2_all_     ,"ToTdistCS2"   ,40,-0.5,39.5);
+        clusterToT_cs3_all_         = addPlot(clusterToT_cs3_all_     ,"ToTdistCS3"   ,60,-0.5,59.5);
+        clusterToT_csn_all_         = addPlot(clusterToT_csn_all_     ,"ToTdistCSn"   ,80, -0.5, 79.5, 30, 0.5, 30.5);
 
         totMax_all_                 = addPlot(totMax_all_             ,"ToTdistCS2_max_ToT", 150,-0.5,149.5);    
         totMin_all_                 = addPlot(totMin_all_             ,"ToTdistCS2_min_ToT", 150,-0.5,149.5);
 
-        clusterSize_all_            = addPlot(clusterSize_all_        ,"CSdist"       , 50, 0.5, 50.5);
-        clusterSizeRow_all_         = addPlot(clusterSizeRow_all_     ,"CSdistRow"    , 50, 0.5, 50.5);
-        clusterSizeCol_all_         = addPlot(clusterSizeCol_all_     ,"CSdistCol"    , 50, 0.5, 50.5); 
+        clusterSize_all_            = addPlot(clusterSize_all_        ,"CSdist"       , 30, 0.5, 30.5);
+        clusterSizeRow_all_         = addPlot(clusterSizeRow_all_     ,"CSdistRow"    , 30, 0.5, 30.5);
+        clusterSizeCol_all_         = addPlot(clusterSizeCol_all_     ,"CSdistCol"    , 30, 0.5, 30.5); 
 
+        clusterMap_all_             = addPlot(clusterMap_all_           ,"clusterMap_all"       ,80*2,0,80*2,336*2,0,336*2);
         clusterMap_cs1_all_         = addPlot(clusterMap_cs1_all_       ,"clusterMap_cs1"       ,80*2,0,80*2,336*2,0,336*2);
         clusterMap_cs2_all_         = addPlot(clusterMap_cs2_all_       ,"clusterMap_cs2"       ,80*2,0,80*2,336*2,0,336*2);
         clusterTotMap_cs1_all_      = addPlot(clusterTotMap_cs1_all_    ,"clusterTotMap_cs1"    ,80*2,0,80*2,336*2,0,336*2);
@@ -230,18 +231,18 @@ void Plotter::fillClusterPlots(Clusterizer::clusterMapDef &clusterMap, double no
             {
                 std::cout << "Making new cluster histograms for chip: " << (*chip).first << std::endl;
 
-                addPlot(clusterToT_      ,"ToTdist"         ,(*chip).first, 150, -0.5, 149.5);
-                addPlot(clusterToT_cs1_  ,"ToTdistCS1"      ,(*chip).first, 150, -0.5, 149.5);
-                addPlot(clusterToT_cs2_  ,"ToTdistCS2"      ,(*chip).first, 150, -0.5, 149.5);
-                addPlot(clusterToT_cs3_  ,"ToTdistCS3"      ,(*chip).first, 150, -0.5, 149.5);
-                addPlot(clusterToT_csn_  ,"ToTdistCSn"      ,(*chip).first, 150, -0.5, 149.5, 50, 0.5, 50.5);
+                addPlot(clusterToT_      ,"ToTdist"         ,(*chip).first, 80,-0.5,79.5);
+                addPlot(clusterToT_cs1_  ,"ToTdistCS1"      ,(*chip).first, 20,-0.5,19.5);
+                addPlot(clusterToT_cs2_  ,"ToTdistCS2"      ,(*chip).first, 40,-0.5,39.5);
+                addPlot(clusterToT_cs3_  ,"ToTdistCS3"      ,(*chip).first, 60,-0.5,59.5);
+                addPlot(clusterToT_csn_  ,"ToTdistCSn"      ,(*chip).first, 80, -0.5, 79.5, 30, 0.5, 30.5);
 
                 addPlot(totMax_          ,"ToTdistCS2_max_ToT"  ,(*chip).first, 150, -0.5, 149.5);
                 addPlot(totMin_          ,"ToTdistCS2_min_ToT"  ,(*chip).first, 150, -0.5, 149.5);
 
-                addPlot(clusterSize_     ,"CSdist"            ,(*chip).first,  50,  0.5,  50.5);
-                addPlot(clusterSizeRow_  ,"CSdistRow"         ,(*chip).first,  50,  0.5,  50.5);
-                addPlot(clusterSizeCol_  ,"CSdistCol"         ,(*chip).first,  50,  0.5,  50.5);
+                addPlot(clusterSize_     ,"CSdist"            ,(*chip).first,  30,  0.5,  30.5);
+                addPlot(clusterSizeRow_  ,"CSdistRow"         ,(*chip).first,  30,  0.5,  30.5);
+                addPlot(clusterSizeCol_  ,"CSdistCol"         ,(*chip).first,  30,  0.5,  30.5);
 
                 addPlot(clusterMap_cs1_       ,"clusterMap_cs1"       ,(*chip).first,cols,0,cols,rows,0,rows);
                 addPlot(clusterMap_cs2_       ,"clusterMap_cs2"       ,(*chip).first,cols,0,cols,rows,0,rows);
@@ -413,20 +414,22 @@ void Plotter::fillClusterPlots(Clusterizer::clusterMapDef &clusterMap, double no
                     if( cSize==3 ) 
                     {
                         clusterToT_cs3_[(*chip).first]->Fill(cToT);
-                        if(chargeSum !=0 ) clusterCharge_cs3_[(*chip).first]->Fill(chargeSum); 
+                        if(chargeSum !=0 ) clusterCharge_cs3_[(*chip).first]->Fill(chargeSum);
                     }
                     if(isQuad_)
                     {
                         this->quadEncode((*chip).first, cCol, cRow);
+                        clusterMap_all_->Fill(cCol, cRow);
+
                         if( cSize==1 )
                         {
-                            clusterMap_cs1_all_->Fill(cCol, cRow);     
-                            clusterTotMap_cs1_all_->Fill(cCol, cRow,cToT);
+                            clusterMap_cs1_all_->Fill(cCol, cRow);
+                            clusterTotMap_cs1_all_->Fill(cCol, cRow, cToT);
                         }
                         if( cSize==2 )
                         {
                             clusterMap_cs2_all_->Fill(cCol, cRow);
-                            clusterTotMap_cs2_all_->Fill(cCol, cRow,cToT);
+                            clusterTotMap_cs2_all_->Fill(cCol, cRow, cToT);
                         }
                     }
                     if(save_cluster_data_)
@@ -726,6 +729,7 @@ void Plotter::writePlots(std::string rootFileName)
         clusterSizeCol_all_->Write();
 
         hitMap_all_->Write();
+        clusterMap_all_->Write(); 
         clusterMap_cs1_all_->Write();   
         clusterMap_cs2_all_->Write();   
         clusterTotMap_cs1_all_->Write();    

--- a/src/Plotter.cpp
+++ b/src/Plotter.cpp
@@ -439,26 +439,43 @@ void Plotter::fillClusterPlots(Clusterizer::clusterMapDef &clusterMap, double no
         }
     }
 
+    clusterToT_all_       ->Reset();
+    clusterToT_cs1_all_   ->Reset();
+    clusterToT_cs2_all_   ->Reset();
+    clusterToT_cs3_all_   ->Reset();
+    clusterToT_csn_all_   ->Reset();
+    totMax_all_           ->Reset();
+    totMin_all_           ->Reset();
+    clusterSize_all_      ->Reset();
+    clusterSizeRow_all_   ->Reset();
+    clusterSizeCol_all_   ->Reset();
+    if(use_charge_calibration_)
+    {
+        clusterCharge_all_      ->Reset();
+        clusterCharge_cs1_all_  ->Reset();
+        clusterCharge_cs2_all_  ->Reset();
+    }
+
     for(std::map<int, TH1I*>::iterator chip=clusterToT_.begin(); chip!=clusterToT_.end(); ++chip)
     {
         clusterMeanTotMap_cs1_[(*chip).first]->Divide(clusterTotMap_cs1_[(*chip).first],clusterMap_cs1_[(*chip).first],1.0,1.0,"B");
         clusterMeanTotMap_cs2_[(*chip).first]->Divide(clusterTotMap_cs2_[(*chip).first],clusterMap_cs2_[(*chip).first],1.0,1.0,"B");
 
         if(isQuad_)
-        {
+        {            
             clusterToT_all_       ->Add( (*chip).second                   );
             clusterToT_cs1_all_   ->Add( clusterToT_cs1_[(*chip).first]   );
             clusterToT_cs2_all_   ->Add( clusterToT_cs2_[(*chip).first]   );
             clusterToT_cs3_all_   ->Add( clusterToT_cs3_[(*chip).first]   );
             clusterToT_csn_all_   ->Add( clusterToT_csn_[(*chip).first]   );
-            totMax_all_           ->Add( totMax_[(*chip).first]           );  
-            totMin_all_           ->Add( totMin_[(*chip).first]           );  
-            clusterSize_all_      ->Add( clusterSize_[(*chip).first]      );  
-            clusterSizeRow_all_   ->Add( clusterSizeRow_[(*chip).first]   );  
+            totMax_all_           ->Add( totMax_[(*chip).first]           );
+            totMin_all_           ->Add( totMin_[(*chip).first]           );
+            clusterSize_all_      ->Add( clusterSize_[(*chip).first]      );
+            clusterSizeRow_all_   ->Add( clusterSizeRow_[(*chip).first]   );
             clusterSizeCol_all_   ->Add( clusterSizeCol_[(*chip).first]   );
             if(use_charge_calibration_)
             {
-                clusterCharge_all_    ->Add( clusterCharge_[(*chip).first]    );  
+                clusterCharge_all_    ->Add( clusterCharge_[(*chip).first]    );
                 clusterCharge_cs1_all_->Add( clusterCharge_cs1_[(*chip).first]);
                 clusterCharge_cs2_all_->Add( clusterCharge_cs2_[(*chip).first]);
             }


### PR DESCRIPTION
Hot fix for #2 

Resets the histograms before they are filled, but it would be better to fill them only once or to pass only bunched clusters to the plotter.